### PR TITLE
fix: nsx health false negative

### DIFF
--- a/VMware.CloudFoundation.Reporting.psm1
+++ b/VMware.CloudFoundation.Reporting.psm1
@@ -3570,26 +3570,22 @@ Function Request-NsxtComputeManagerStatus {
                                 $component = 'Compute Manager' # Define the component name
                                 $resource = $vcfNsxDetails.fqdn # Define the resource name
 
-                                # Get the status of the compute manager
-                                if (Get-VCFWorkloadDomain | Where-Object { $_.name -eq $domain -and $_.vcenters.fqdn -ne $computeManager.server }) {
-                                    $status = 'ROGUE'
+                                # Set the alert and message based on the status of the compute manager
+                                if ($computeManager.server -notin (( Get-VCFWorkloadDomain | Where-Object { $_.nsxtCluster.vipFqdn -eq $vcfNsxDetails.fqdn }).vcenters.fqdn) ) {
+                                    $alert = 'RED' # Critical; rogue addition detected
+                                    $message = "$($computeManager.server) has been detected as a rogue addition." # Critical; rogue addition detected
                                 } else {
                                     $status = (Get-NsxtComputeManagerStatus -id $computeManager.id)
-                                }
-
-                                # Set the alert and message based on the status of the compute manager
-                                if ($status.registration_status -eq 'REGISTERED' -and $status.connection_status -eq 'UP') {
+                                    if ($status.registration_status -eq 'REGISTERED' -and $status.connection_status -eq 'UP') {
                                     $alert = 'GREEN' # Ok; registered and up
                                     $message = "$($computeManager.server) is registered and healthy." # Ok; registered and up
                                 } elseif ($status.registration_status -eq 'REGISTERED' -and $status.connection_status -ne 'UP') {
                                     $alert = 'RED' # Critical; registered and not up
                                     $message = "$($computeManager.server) is registered but unhealthy." # Critical; registered and not up
-                                } elseif ($status -eq 'ROGUE') {
-                                    $alert = 'RED' # Critical; rogue addition detected
-                                    $message = "$($computeManager.server) has been detected as a rogue addition." # Critical; rogue addition detected
                                 } else {
                                     $alert = 'RED' # Critical; not registered
                                     $message = "$($computeManager.server) is not registered." # Critical; not registered
+                                }
                                 }
 
                                 # Add the properties to the element object


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/powershell-module-for-cloud-foundation-reorting/blob/main/CONTRIBUTING_DCO.md) for making a pull request.

**Summary of Pull Request**

<!--
    Please provide a clear and concise description of the pull request.
-->

Resolves the false negative for "rogue" compute managers (vCenter Server instances) registered in NSX on the Health Report when using NSX:VC _1:many_ for workload domains.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Resolves #28

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
