### PR TITLE
Fix Test-VcfReportingPrereq cmdlet

### DIFF
--- a/VMware.CloudFoundation.Reporting.psm1
+++ b/VMware.CloudFoundation.Reporting.psm1
@@ -8623,30 +8623,15 @@ Function Test-VcfReportingPrereq {
             @{ Name=("PowerValidatedSolutions"); Version=("2.0.0")}
         )
         foreach ($module in $modules ) {
-            if ($PSEdition -eq "Desktop") {
-                if ((Get-InstalledModule -Name $module.Name).Version -lt $module.Version) {
-                    $message = "PowerShell Module: $($module.Name) Version: $($module.Version) Not Installed, Please update before proceeding."
-                    Write-Warning $message; Write-Host ""
-					Break
-                } else {
-                    $moduleCurrentVersion = (Get-InstalledModule -Name $module.Name).Version
-                    $message = "PowerShell Module: $($module.Name) Version: $($moduleCurrentVersion) Found, Supports the minimum required version."
-                    $message
-                }
+            if ((Get-InstalledModule -Name $module.Name).Version -lt $module.Version) {
+                $message = "PowerShell Module: $($module.Name) Version: $($module.Version) Not Installed, Please update before proceeding."
+                Write-Warning $message; Write-Host ""
+                break
             } else {
-                if (!$module -eq "VMware.PowerCLI") {
-                    if ((Get-Module -Name $module.Name).Version -lt $module.Version) {
-                        $message = "PowerShell Module: $($module.Name) Version: $($module.Version) Not Installed, Please update before proceeding."
-                        Write-Warning $message; Write-Host ""
-					Break
-                    } else {
-                        $moduleCurrentVersion = (Get-InstalledModule -Name $module.Name).Version
-                        $message = "PowerShell Module: $($module.Name) Version: $($moduleCurrentVersion) Found, Supports the minimum required version."
-                        $message
-                    }
-                }
+                $moduleCurrentVersion = (Get-InstalledModule -Name $module.Name).Version
+                $message = "PowerShell Module: $($module.Name) Version: $($moduleCurrentVersion) Found, Supports the minimum required version."
+                $message
             }
-
         }
     }
     Catch {


### PR DESCRIPTION
Signed-off-by: bhumitra nagar <bnagar@vmware.com>

In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/powershell-module-for-cloud-foundation-reorting/blob/main/CONTRIBUTING_DCO.md) for making a pull request.

**Summary of Pull Request**
`Test-VcfReportingPrereq` doesnt return any output on Photon OS
There were following issues with the code logic - 

- `Get-Module` should be changed to `Get-InstalledModule`.
- The `if (!$module -eq "VMware.PowerCLI") ` condition for checking PowerCli module is not correct. 
- Also, upon checking we don't need to have separate conditions for Windows and other OS. Same code works on both powershell core and desktop versions. 

Here is the output after the fix
on Windows - 

```
PS C:\> Test-VcfReportingPrereq
PowerShell Module: VMware.PowerCLI Version: 12.7.0.20091289 Found, Supports the minimum required version.
PowerShell Module: VMware.vSphere.SsoAdmin Version: 1.3.8 Found, Supports the minimum required version.
PowerShell Module: PowerVCF Version: 2.2.0 Found, Supports the minimum required version.
WARNING: PowerShell Module: PowerValidatedSolutions Version: 2.0.0 Not Installed, Please update before proceeding.

PS C:\>
```

On Photon OS

```
PS /root/.local/share/powershell/Modules/VMware.CloudFoundation.Reporting/1.0.5.1002> Test-VcfReportingPrereq
PowerShell Module: VMware.PowerCLI Version: 13.0.0.20829139 Found, Supports the minimum required version.
PowerShell Module: VMware.vSphere.SsoAdmin Version: 1.3.8 Found, Supports the minimum required version.
PowerShell Module: PowerVCF Version: 2.2.0 Found, Supports the minimum required version.
WARNING: PowerShell Module: PowerValidatedSolutions Version: 2.0.0 Not Installed, Please update before proceeding.


```

<!--
    Please provide a clear and concise description of the pull request.
-->

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: 81

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
