### PR TITLE
fix: vrealize product display name

### DIFF
--- a/VMware.CloudFoundation.Reporting.psm1
+++ b/VMware.CloudFoundation.Reporting.psm1
@@ -8733,21 +8733,38 @@ Function Request-VrealizeOverview {
                 $vcfApiCmdlet = @("Get-VCFvRSLCM","Get-VCFWSA","Get-VCFvRLI","Get-VCFvROPS","Get-VCFvRA")
                 foreach ($apiCmdlet in $vcfApiCmdlet) {
                     if ((Invoke-Expression $apiCmdlet).status -eq "ACTIVE") {
-                        if ($apiCmdlet -eq "Get-VCFvRSLCM") {$nodeCount = "1" } else { ($nodeCount = ((Invoke-Expression $apiCmdlet).nodes).Count)}
+                        if ($apiCmdlet -eq "Get-VCFvRSLCM") {$nodeCount = "1"} else { ($nodeCount = ((Invoke-Expression $apiCmdlet).nodes).Count)}
+
+                        if ($apiCmdlet -eq "Get-VCFvRSLCM") {
+                            $product = "vRealize Suite Lifecycle Manager"
+                        }
+                        elseif ($apiCmdlet -eq "Get-VCFWSA") {
+                            $product = "Workspace ONE Access"
+                        }
+                        elseif ($apiCmdlet -eq "Get-VCFvRLI") {
+                            $product = "vRealize Log Insight"
+                        }
+                        elseif ($apiCmdlet -eq "Get-VCFvROPS") {
+                            $product = "vRealize Operations"
+                        }
+                        elseif ($apiCmdlet -eq "Get-VCFvRA") {
+                            $product = "vRealize Automation"
+                        }
+                        
                         $customObject = New-Object -TypeName psobject
-                        $customObject | Add-Member -notepropertyname "vRealize Product" -notepropertyvalue ((Get-Help -Name $apiCmdlet).synopsis -Split ("Get the existing ") | Select-Object -Last 1)
-                        if ($PsBoundParameters.ContainsKey('anonymized')) {
-                            $customObject | Add-Member -notepropertyname "UUID" -notepropertyvalue (Invoke-Expression $apiCmdlet).id
+                        $customObject | Add-Member -NotePropertyName "vRealize Product" -NotePropertyValue $product
+                        if ($PsBoundParameters.ContainsKey("anonymized")) {
+                            $customObject | Add-Member -NotePropertyName "UUID" -NotePropertyValue (Invoke-Expression $apiCmdlet).id
                         } else {
                             if ($apiCmdlet -eq "Get-VCFvRSLCM") {
-                                $customObject | Add-Member -notepropertyname "FQDN" -notepropertyvalue (Invoke-Expression $apiCmdlet).fqdn
+                                $customObject | Add-Member -NotePropertyName "FQDN" -NotePropertyValue (Invoke-Expression $apiCmdlet).fqdn
                             } else {
-                                $customObject | Add-Member -notepropertyname "FQDN" -notepropertyvalue (Invoke-Expression $apiCmdlet).loadBalancerFqdn
+                                $customObject | Add-Member -NotePropertyName "FQDN" -NotePropertyValue (Invoke-Expression $apiCmdlet).loadBalancerFqdn
                             }
                         }
-                        $customObject | Add-Member -notepropertyname "Version" -notepropertyvalue (Invoke-Expression $apiCmdlet).version
-                        $customObject | Add-Member -notepropertyname "Status" -notepropertyvalue (Invoke-Expression $apiCmdlet).status
-                        $customObject | Add-Member -notepropertyname "Nodes" -notepropertyvalue $nodeCount
+                        $customObject | Add-Member -NotePropertyName "Version" -NotePropertyValue (Invoke-Expression $apiCmdlet).version
+                        $customObject | Add-Member -NotePropertyName "Status" -NotePropertyValue (Invoke-Expression $apiCmdlet).status
+                        $customObject | Add-Member -NotePropertyName "Nodes" -NotePropertyValue $nodeCount
                         $allVrealizeObject += $customObject
                     }
                 }
@@ -8755,7 +8772,7 @@ Function Request-VrealizeOverview {
             }
         }
     }
-	Catch {
+    Catch {
         Debug-ExceptionWriter -object $_
     }
 }


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/powershell-module-for-cloud-foundation-reorting/blob/main/CONTRIBUTING_DCO.md) for making a pull request.

**Summary of Pull Request**

Resolves an issue with the display name of the vRealize Log Insight product name in the **vRealize Suite Overview** due to an upstream error in the `.SYNOPSIS` of `Get-VCFvRLI` in `PowerVCF`.

This change may allow future versions of the module to adopt the rebranding to Aria Suite ahead of PowerVCF.

Signed-off-by: Ryan Johnson <johnsonryan@vmware.com>

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style/formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Issue Number: N/A

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bug fixes/features).
- [ ] Documentation has been added/updated (for bug fixes/features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
