### PR TITLE
reactor: transition to `Publish-PasswordHealth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ Enhancement:
 - Updates `Publish-CertificateHealth` with thresholds based on certificate expiration. [GH-107](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/107)
 - Updates `Publish-CertificateHealth` to include an "Expires In (Days)" column. [GH-107](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/107)
 - Updates `Publish-CertificateHealth` to include ESXi host certificates. [GH-107](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/107)
+- Updates `Publish-PasswordHealth` to include an "Expires In (Days)" column. [GH-111](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/111)
 
 Refactor:
-- Updates `Request-SoSHealthJson` to use the API to retrieve the SoS Health Summary JSON results. Removes the requirement to provide the SDDC Manager appliance `root` password in the `Invoke-VcfHealthReport` cmdlet. [GH-102](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/102), [GH-110](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/110)
+- Updates `Request-SoSHealthJson` to use the API to retrieve the SoS Health Summary JSON results. [GH-102](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/102)
+- Updates `Publish-PasswordHealth` to return the results from the SoS Health Summary JSON data. [GH-111](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/111)
+- Updates `Invoke-VcfHealthReport` to use the `Publish-PasswordHealth` cmdlet. [GH-111](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/111)
+- Removes `Publish-LocalUserExpiry` in favor of the `Publish-PasswordHealth` cmdlet. [GH-111](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/111)
 
 ## [v1.1.0](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/releases/tag/v1.1.0)
 

--- a/VMware.CloudFoundation.Reporting.psd1
+++ b/VMware.CloudFoundation.Reporting.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\VMware.CloudFoundation.Reporting.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.0.0.1003'
+    ModuleVersion = '2.0.0.1004'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/powershell-module-for-cloud-foundation-reorting/blob/main/CONTRIBUTING_DCO.md) for making a pull request.

**Summary of Pull Request**

<!--
    Please provide a clear and concise description of the pull request.
-->

- Updates `Publish-PasswordHealth` to return the results from the SoS Health Summary JSON data. #90
- Updates `Invoke-VcfHealthReport` to use the `Publish-PasswordHealth` cmdlet. #90
- Updates `Publish-PasswordHealth` to include an "Expires In (Days)" column. #40
- Removes `Publish-LocalUserExpiry` in favor of the `Publish-PasswordHealth` cmdlet. #90
- Bumps the module version to v2.0.0.1004.
- Updates `CHANGELOG.md`.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [ ] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [x] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Closes #90 
Closes #40
Closes #39 

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
