### PR TITLE
feat: add vsan cluster health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Enhancement:
 - Updated `Publish-CertificateHealth` to include ESXi host certificates. [GH-107](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/107)
 - Updated `Publish-PasswordHealth` to include an "Expires In (Days)" column. [GH-111](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/111)
 - Added `Show-ReportingOutput` cmdlet to format output to the console when `PowerVCF` is not installed. [GH-121](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/121)
+- Updated `Publish-VsanHealth` to include the results for capacity utilization and the active resysc of objects.
 
 Refactor:
 

--- a/VMware.CloudFoundation.Reporting.psd1
+++ b/VMware.CloudFoundation.Reporting.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\VMware.CloudFoundation.Reporting.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.0.0.1007'
+    ModuleVersion = '2.0.0.1009'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/VMware.CloudFoundation.Reporting.psm1
+++ b/VMware.CloudFoundation.Reporting.psm1
@@ -1989,7 +1989,7 @@ Function Publish-VsanHealth {
             Write-Warning 'vSAN data not found in the JSON file: SKIPPED'
         } else {
 
-            # vSAN Cluster Health Status
+            # Cluster Health Status
             $jsonInputData = $targetContent.vSAN.'Cluster vSAN Status' # Extract Data from the provided SOS JSON
             if ($PsBoundParameters.ContainsKey("failureOnly")) {
                 $outputObject = Read-JsonElement -inputData $jsonInputData -failureOnly # Call Function to Structure the Data for Report Output
@@ -2000,6 +2000,24 @@ Function Publish-VsanHealth {
 
             # Cluster Disk Status
             $jsonInputData = $targetContent.vSAN.'Cluster Disk Status' # Extract Data from the provided SOS JSON
+            if ($PsBoundParameters.ContainsKey("failureOnly")) {
+                $outputObject = Read-JsonElement -inputData $jsonInputData -failureOnly # Call Function to Structure the Data for Report Output
+            } else {
+                $outputObject = Read-JsonElement -inputData $jsonInputData # Call Function to Structure the Data for Report Output
+            }
+            $customObject += $outputObject # Adding individual component to main customObject
+
+            # Cluster Capacity Utilization
+            $jsonInputData = $targetContent.vSAN.'vSAN Capacity Utilization' # Extract Data from the provided SOS JSON
+            if ($PsBoundParameters.ContainsKey("failureOnly")) {
+                $outputObject = Read-JsonElement -inputData $jsonInputData -failureOnly # Call Function to Structure the Data for Report Output
+            } else {
+                $outputObject = Read-JsonElement -inputData $jsonInputData # Call Function to Structure the Data for Report Output
+            }
+            $customObject += $outputObject # Adding individual component to main customObject
+
+            # Cluster Active ReSync Objects
+            $jsonInputData = $targetContent.vSAN.'Active ReSync Objects' # Extract Data from the provided SOS JSON
             if ($PsBoundParameters.ContainsKey("failureOnly")) {
                 $outputObject = Read-JsonElement -inputData $jsonInputData -failureOnly # Call Function to Structure the Data for Report Output
             } else {


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/powershell-module-for-cloud-foundation-reorting/blob/main/CONTRIBUTING_DCO.md) for making a pull request.

**Summary of Pull Request**

<!--
    Please provide a clear and concise description of the pull request.
-->

- Updated `Publish-VsanHealth` to include the results for capacity utilization and the active resysc of objects.
- Bumps the module version to v2.0.0.1009.
- Updates `CHANGELOG.md`.

Ref: #103

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [x] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Closes #103 

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/7771363/231860418-b9b964c3-d78d-4031-aa11-e9261e7dce5b.png">

```powershell
PS F:\> Publish-VsanHealth -json F:\Reporting\HealthReports\sfo-vcf01-all-health-results.json

Component Resource     Alert  Message
--------- --------     -----  -------
vCenter   sfo-m01-cl01 -      Stretched cluster is disabled on cluster: sfo-m01-cl01
vCenter   sfo-m01-cl01 GREEN  There are no Active Re-Syncing happening
vCenter   sfo-m01-cl01 -      Compression is enabled on cluster : sfo-m01-cl01
vCenter   sfo-m01-cl01 -      Deduplication is enabled on cluster : sfo-m01-cl01
vCenter   sfo-m01-cl01 -      Encryption is disabled on cluster : sfo-m01-cl01
vCenter   sfo-m01-cl01 RED    Cluster VSAN Health Check is not successful for following groups ['Capacity utilization']. Please refer to Vcenter Skyline Health for more details about the un-successful tests. Overall t...
vCenter   sfo-m01-cl01 GREEN  All hosts are healthy
vCenter   sfo-m01-cl01 YELLOW vSAN Capacity utilization has reached 70%
vCenter   sfo-w01-cl01 -      Deduplication is disabled on cluster : sfo-w01-cl01
vCenter   sfo-w01-cl01 GREEN  There are no Active Re-Syncing happening
vCenter   sfo-w01-cl01 -      Stretched cluster is disabled on cluster: sfo-w01-cl01
vCenter   sfo-w01-cl01 YELLOW Cluster VSAN Health Check is not successful for following groups ['Online health (Disabled)']. Please refer to Vcenter Skyline Health for more details about the un-successful tests. Overa...
vCenter   sfo-w01-cl01 GREEN  All hosts are healthy
vCenter   sfo-w01-cl01 GREEN  vSAN Capacity utilization is well within thresholds
vCenter   sfo-w01-cl01 -      Encryption is disabled on cluster : sfo-w01-cl01
vCenter   sfo-w01-cl01 -      Compression is disabled on cluster : sfo-w01-cl01

PS F:\> Publish-VsanHealth -json F:\Reporting\HealthReports\sfo-vcf01-all-health-results.json -failureOnly

Component Resource     Alert  Message
--------- --------     -----  -------
vCenter   sfo-m01-cl01 YELLOW vSAN Capacity utilization has reached 70%
vCenter   sfo-m01-cl01 RED    Cluster VSAN Health Check is not successful for following groups ['Capacity utilization']. Please refer to Vcenter Skyline Health for more details about the un-successful tests. Overall t...
vCenter   sfo-w01-cl01 YELLOW Cluster VSAN Health Check is not successful for following groups ['Online health (Disabled)']. Please refer to Vcenter Skyline Health for more details about the un-successful tests. Overa...
```

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
