### PR TITLE
feat: add component size checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Enhancement:
 
 - Added `Publish-HardwareCompatibilityHealth` to return the hardware compatibilty health from the SoS Health Summary JSON data. [GH-129](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/129)
 - Updated `Invoke-VcfHealthReport` to include the hardware compatibility health using the `Publish-HardwareCompatibilityHealth` cmdlet. [GH-129](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/129)
+- Added component size checks for vCenter Server instances and NSX Local Manager clusters to the overview report. [GH-130](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/130)
 
 ## [v2.0.0](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/releases/tag/v2.0.0)
 

--- a/VMware.CloudFoundation.Reporting.psd1
+++ b/VMware.CloudFoundation.Reporting.psd1
@@ -12,7 +12,7 @@
     RootModule = '.\VMware.CloudFoundation.Reporting.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.1.0.1001'
+    ModuleVersion = '2.1.0.1002'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you read the [contributing guidelines](https://github.com/vmware/powershell-module-for-cloud-foundation-reorting/blob/main/CONTRIBUTING_DCO.md) for making a pull request.

**Summary of Pull Request**

<!--
    Please provide a clear and concise description of the pull request.
-->

- Added component size checks (e.g., tiny, x-small, small, etc...) for vCenter Server instances and NSX Local Manager clusters to the overview report.
- Updates `CHANGELOG.md`
- Updates module version from v2.1.0.1001 to v2.1.0.1002.

**Type of Pull Request**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] This is a bug fix.
- [x] This is an enhancement or feature.
- [ ] This is a code style / formatting update.
- [ ] This is a documentation update.
- [ ] This is a refactoring update.
- [ ] This is a chore update
- [ ] This is something else.
      Please describe:

**Related to Existing Issues**

<!--
  Is this related to any GitHub issue(s)?
-->

Closes #71 

**Test and Documentation Coverage**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [x] Tests have been completed (for bug fixes / features).
- [ ] Documentation has been added / updated (for bug fixes / features).

```powershell
PS F:\> Request-VcenterOverview -server sfo-vcf01.sfo.rainpole.io -user admin@local -pass VMw@re1!VMw@re1!

vCenter Server FQDN : sfo-m01-vc01.sfo.rainpole.io
Version             : 7.0.3.01000-20395099
Domain Name         : sfo-m01
Domain Type         : management
Size                : small
CPU                 : 4
Memory (GB)         : 19
Total Clusters      : 1
Total Hosts         : 4
Total VMs           : 41
Powered On VMs      : 40
Powered Off VMs     : 1

vCenter Server FQDN : sfo-w01-vc01.sfo.rainpole.io
Version             : 7.0.3.01000-20395099
Domain Name         : sfo-w01
Domain Type         : vi
Size                : medium
CPU                 : 8
Memory (GB)         : 28
Total Clusters      : 1
Total Hosts         : 3
Total VMs           : 24
Powered On VMs      : 22
Powered Off VMs     : 2

PS F:\> Request-NetworkOverview -server sfo-vcf01.sfo.rainpole.io -user admin@local -pass VMw@re1!VMw@re1!

NSX Manager Cluster FQDN : sfo-m01-nsx01.sfo.rainpole.io
Version                  : 3.2.1.2.0-20541212
Domain Name              : sfo-m01
Domain Type              : management
Shared                   : False
Size                     : medium
CPU                      : 6
Memory (GB)              : 24
Edge Cluster             : True
AVN                      : True

NSX Manager Cluster FQDN : sfo-w01-nsx01.sfo.rainpole.io
Version                  : 3.2.1.2.0-20541212
Domain Name              : sfo-w01
Domain Type              : vi
Shared                   : False
Size                     : medium
CPU                      : 6
Memory (GB)              : 24
Edge Cluster             : True
AVN                      : False
```

<img width="1758" alt="image" src="https://user-images.githubusercontent.com/7771363/233490304-83414acc-b07d-4d23-80de-f88ce89997f4.png">

**Breaking Changes?**

<!--
    Please check the one that applies to this pull request using "x".
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

<!--
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->
