### PR TITLE
fix: report output failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## v2.6.2
+
+> Release Date: (unreleased)
+
+Bugfix:
+
+- Updated `Invoke-VcfHealthReport` cmdlet to handle . or - in the report path. [GH-217](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/217)
+- Updated `Invoke-VcfAlertReport` cmdlet to handle . or - in the report path. [GH-217](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/217)
+- Updated `Invoke-VcfConfigReport` cmdlet to handle . or - in the report path. [GH-217](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/217)
+- Updated `Invoke-VcfUpgradePrecheck` cmdlet to handle . or - in the report path. [GH-217](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/217)
+- Updated `Invoke-VcfOverviewReport` cmdlet to handle . or - in the report path. [GH-217](https://github.com/vmware/powershell-module-for-vmware-cloud-foundation-reporting/pull/217)
+
 ## v2.6.1
 
 > Release Date: 2024-02-06

--- a/VMware.CloudFoundation.Reporting.psd1
+++ b/VMware.CloudFoundation.Reporting.psd1
@@ -11,7 +11,7 @@
     RootModule = '.\VMware.CloudFoundation.Reporting.psm1'
     
     # Version number of this module.
-    ModuleVersion = '2.6.1.1001'
+    ModuleVersion = '2.6.2.1000'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/VMware.CloudFoundation.Reporting.psm1
+++ b/VMware.CloudFoundation.Reporting.psm1
@@ -286,7 +286,7 @@ Function Invoke-VcfHealthReport {
                 $defaultReport = Start-CreateReportDirectory -path $reportPath -reportType health # Setup Report Location and Report File
                 if (!(Test-Path -Path $reportPath)) {Write-Warning "Unable to locate report path $reportPath, enter a valid path and try again"; Write-Host ""; Break }
                 if ($PsBoundParameters.ContainsKey("allDomains")) {
-                    $reportname = $defaultReport.Split('.')[0] + "-" + $sddcManagerFqdn.Split(".")[0] + ".htm"
+                    $reportname = $defaultReport.Split('-health')[0] + "-health-" + $sddcManagerFqdn.Split(".")[0] + ".htm"
                     $reportData = "<h1>SDDC Manager: $sddcManagerFqdn</h1>"
                     $workflowMessage = "VMware Cloud Foundation instance ($sddcManagerFqdn)"
                     $commandSwitch = "-allDomains"
@@ -501,7 +501,7 @@ Function Invoke-VcfAlertReport {
                 $defaultReport = Start-CreateReportDirectory -path $reportPath -reportType alert # Setup Report Location and Report File
                 if (!(Test-Path -Path $reportPath)) {Write-Warning "Unable to locate report path $reportPath, enter a valid path and try again"; Write-Host ""; Break }
                 if ($PsBoundParameters.ContainsKey("allDomains")) {
-                    $reportname = $defaultReport.Split('.')[0] + "-" + $sddcManagerFqdn.Split(".")[0] + ".htm"
+                    $reportname = $defaultReport.Split('-alert')[0] + "-alert-" + $sddcManagerFqdn.Split(".")[0] + ".htm"
                     $reportData = "<h1>SDDC Manager: $sddcManagerFqdn</h1>"
                     $workflowMessage = "VMware Cloud Foundation instance ($sddcManagerFqdn)"
                     $commandSwitch = "-allDomains"
@@ -625,7 +625,7 @@ Function Invoke-VcfConfigReport {
                 $defaultReport = Start-CreateReportDirectory -path $reportPath -reportType config # Setup Report Location and Report File
                 if (!(Test-Path -Path $reportPath)) {Write-Warning "Unable to locate report path $reportPath, enter a valid path and try again"; Write-Host ""; Break }
                 if ($PsBoundParameters.ContainsKey("allDomains")) {
-                    $reportname = $defaultReport.Split('.')[0] + "-" + $sddcManagerFqdn.Split(".")[0] + ".htm"
+                    $reportname = $defaultReport.Split('-config')[0] + "-config-" + $sddcManagerFqdn.Split(".")[0] + ".htm"
                     $reportData = "<h1>SDDC Manager: $sddcManagerFqdn</h1>"
                     $workflowMessage = "VMware Cloud Foundation instance ($sddcManagerFqdn)"
                     $commandSwitch = "-allDomains"
@@ -742,7 +742,7 @@ Function Invoke-VcfUpgradePrecheck {
             if (Test-VCFAuthentication -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass) {
                 $defaultReport = Start-CreateReportDirectory -path $reportPath -reportType upgrade # Setup Report Location and Report File
                 if (!(Test-Path -Path $reportPath)) {Write-Warning "Unable to locate report path $reportPath, enter a valid path and try again"; Write-Host ""; Break }
-                $reportname = $defaultReport.Split('.')[0] + "-" + $workloadDomain + ".htm"
+                $reportname = $defaultReport.Split('-upgrade')[0] + "-upgrade-" + $workloadDomain + ".htm"
                 $workflowMessage = "Workload Domain ($workloadDomain)"
                 Start-SetupLogFile -Path $reportPath -ScriptName $MyInvocation.MyCommand.Name # Setup Log Location and Log File
                 Write-LogMessage -Type INFO -Message "Starting the Process of Running an Upgrade Precheck for $workflowMessage." -Colour Yellow
@@ -883,7 +883,7 @@ Function Invoke-VcfOverviewReport {
             if (Test-VCFAuthentication -server $sddcManagerFqdn -user $sddcManagerUser -pass $sddcManagerPass) {
                 $defaultReport = Start-CreateReportDirectory -path $reportPath -reportType overview # Setup Report Location and Report File
                 if (!(Test-Path -Path $reportPath)) {Write-Warning "Unable to locate report path $reportPath, enter a valid path and try again"; Write-Host ""; Break }
-                $reportname = $defaultReport.Split('.')[0] + "-" + $sddcManagerFqdn.Split(".")[0] + ".htm"
+                $reportname = $defaultReport.Split('-overview')[0] + "-overview-" + $sddcManagerFqdn.Split(".")[0] + ".htm"
                 $workflowMessage = "VMware Cloud Foundation instance ($sddcManagerFqdn)"
                 Start-SetupLogFile -Path $reportPath -ScriptName $MyInvocation.MyCommand.Name # Setup Log Location and Log File
                 Write-LogMessage -Type INFO -Message "Starting the Process of Creating a System Overview Report for $workflowMessage." -Colour Yellow


### PR DESCRIPTION
### Summary

- Updated `Invoke-VcfHealthReport` cmdlet to handle . or - in the report path.
- Updated `Invoke-VcfAlertReport` cmdlet to handle . or - in the report path.
- Updated `Invoke-VcfConfigReport` cmdlet to handle . or - in the report path.
- Updated `Invoke-VcfUpgradePrecheck` cmdlet to handle . or - in the report path.
- Updated `Invoke-VcfOverviewReport` cmdlet to handle . or - in the report path.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] Bugfix
- [ ] Enhancement or Feature
- [ ] Code Style or Formatting
- [ ] Documentation
- [ ] Refactoring
- [ ] Chore
- [ ] Other
        Please describe:

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Test and Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been completed.
- [ ] Documentation has been added or updated.

<!--
    Please describe the tests that have been completed and/or the documentation that has been added/updated.
-->

### Issue References

Closes #216 

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->
